### PR TITLE
Adding round robin failover for RabbitMQ module

### DIFF
--- a/lib/logstash/outputs/rabbitmq.rb
+++ b/lib/logstash/outputs/rabbitmq.rb
@@ -22,7 +22,7 @@ class LogStash::Outputs::RabbitMQ < LogStash::Outputs::Base
   #
 
   # RabbitMQ server address
-  config :host, :validate => :string, :required => true
+  config :host, :validate => :array, :required => true
 
   # RabbitMQ port to connect on
   config :port, :validate => :number, :default => 5672
@@ -42,7 +42,8 @@ class LogStash::Outputs::RabbitMQ < LogStash::Outputs::Base
   # Validate SSL certificate
   config :verify_ssl, :validate => :boolean, :default => false
 
-  # Enable or disable logging
+  # Enable or disable logging. Repurposed to apply changes for testing
+  # Hides certain error messages and makes initial host selection deterministic.
   config :debug, :validate => :boolean, :default => false, :deprecated => "Use the logstash --debug flag for this instead."
 
 

--- a/lib/logstash/outputs/rabbitmq/bunny.rb
+++ b/lib/logstash/outputs/rabbitmq/bunny.rb
@@ -14,6 +14,12 @@ class LogStash::Outputs::RabbitMQ
 
       @logger.info("Registering output", :plugin => self)
 
+      if @debug || @host.length == 1
+        @cur_index = 0
+      else
+        @cur_index = rand(@host.length)
+      end
+
       connect
       declare_exchange
     end # def register
@@ -45,10 +51,10 @@ class LogStash::Outputs::RabbitMQ
 
         @logger.error("RabbitMQ connection error: #{e.message}. Will attempt to reconnect in #{n} seconds...",
                       :exception => e,
-                      :backtrace => e.backtrace)
+                      :backtrace => e.backtrace) if not @debug
         return if terminating?
 
-        sleep n
+        sleep n if @host.length == 1
         connect
         declare_exchange
         retry
@@ -56,7 +62,7 @@ class LogStash::Outputs::RabbitMQ
     end
 
     def to_s
-      return "amqp://#{@user}@#{@host}:#{@port}#{@vhost}/#{@exchange_type}/#{@exchange}\##{@key}"
+      return "amqp://#{@user}@#{@host[0]}:#{@port}#{@vhost}/#{@exchange_type}/#{@exchange}\##{@key}"
     end
 
     def teardown
@@ -73,15 +79,18 @@ class LogStash::Outputs::RabbitMQ
     #
 
     def connect
+      host, port = @host[@cur_index].split(":")
+      @cur_index = (@cur_index + 1) % @host.length
+
       @vhost       ||= Bunny::DEFAULT_HOST
       # 5672. Will be switched to 5671 by Bunny if TLS is enabled.
-      @port        ||= AMQ::Protocol::DEFAULT_PORT
+      port         ||= @port || AMQ::Protocol::DEFAULT_PORT
       @routing_key ||= "#"
 
       @settings = {
         :vhost => @vhost,
-        :host  => @host,
-        :port  => @port,
+        :host  => host,
+        :port  => port,
         :automatically_recover => false
       }
       @settings[:user]      = @user || Bunny::DEFAULT_USER
@@ -105,7 +114,7 @@ class LogStash::Outputs::RabbitMQ
                                else
                                  "amqps"
                                end
-      @connection_url        = "#{proto}://#{@user}@#{@host}:#{@port}#{vhost}/#{@queue}"
+      @connection_url        = "#{proto}://#{@user}@#{host}:#{port}#{vhost}/#{@queue}"
 
       begin
         @conn = Bunny.new(@settings)
@@ -121,11 +130,15 @@ class LogStash::Outputs::RabbitMQ
 
         @logger.error("RabbitMQ connection error: #{e.message}. Will attempt to reconnect in #{n} seconds...",
                       :exception => e,
-                      :backtrace => e.backtrace)
+                      :backtrace => e.backtrace) if not @debug
         return if terminating?
 
-        sleep n
-        retry
+        if @host.length == 1
+          sleep n
+          retry
+        else
+          connect # Try another server
+        end
       end
     end
 

--- a/spec/outputs/rabbitmq_spec.rb
+++ b/spec/outputs/rabbitmq_spec.rb
@@ -69,4 +69,284 @@ describe LogStash::Outputs::RabbitMQ do
     end
 
   end
+
+  describe "fail over to multiple instances" do
+    require "march_hare"
+
+    config <<-END
+      input {
+        generator {
+          count => 1
+        }
+      }
+      output {
+        rabbitmq {
+          host => ["host1", "host2"]
+          exchange_type => "topic"
+          exchange => "foo"
+          key => "bar"
+          debug => true
+        }
+      }
+    END
+
+    it "should accept multiple hosts" do
+      exchange = double("exchange")
+      conn = double("conn")
+      channel = double("channel")
+
+      # Connect to host1
+      expect(MarchHare).to receive(:connect).with({
+        :vhost => "/",
+        :host => "host1",
+        :port => 5672,
+        :user => "guest",
+        :pass => "guest",
+        :automatic_recovery => false
+      }).and_return(conn)
+      expect(conn).to receive(:create_channel).and_return(channel)
+      expect(channel).to receive(:exchange).with("foo", {
+        :type => :topic,
+        :durable => true
+      }).and_return(exchange)
+
+      expect(exchange).to receive(:publish).with(an_instance_of(String), {
+        :routing_key => "bar",
+        :properties => {:persistent => true}
+      }).and_raise(MarchHare::Exception)
+
+      # Failover to host2
+      expect(MarchHare).to receive(:connect).with({
+        :vhost => "/",
+        :host => "host2",
+        :port => 5672,
+        :user => "guest",
+        :pass => "guest",
+        :automatic_recovery => false
+      }).and_return(conn)
+      expect(conn).to receive(:create_channel).and_return(channel)
+      expect(channel).to receive(:exchange).with("foo", {
+        :type => :topic,
+        :durable => true
+      }).and_return(exchange)
+
+      # Failover back to host1
+      expect(exchange).to receive(:publish).with(an_instance_of(String), {
+        :routing_key => "bar",
+        :properties => {:persistent => true}
+      }).and_raise(MarchHare::Exception)
+
+      expect(MarchHare).to receive(:connect).with({
+        :vhost => "/",
+        :host => "host1",
+        :port => 5672,
+        :user => "guest",
+        :pass => "guest",
+        :automatic_recovery => false
+      }).and_return(conn)
+      expect(conn).to receive(:create_channel).and_return(channel)
+      expect(channel).to receive(:exchange).with("foo", {
+        :type => :topic,
+        :durable => true
+      }).and_return(exchange)
+
+      # Succeed and finish
+      expect(exchange).to receive(:publish).with(an_instance_of(String), {
+        :routing_key => "bar",
+        :properties => {:persistent => true}
+      })
+
+      expect(conn).to receive(:open?).and_return(true)
+      expect(conn).to receive(:close)
+
+      # Run this scenerio
+      pipeline = LogStash::Pipeline.new(config)
+      pipeline.run
+    end
+
+    it "should failover upon failing to connect" do
+      conn = double("conn")
+      channel = double("channel")
+      exchange = double("exchange")
+
+      # Fail to connect to host1
+      expect(MarchHare).to receive(:connect).with({
+        :vhost => "/",
+        :host => "host1",
+        :port => 5672,
+        :user => "guest",
+        :pass => "guest",
+        :automatic_recovery => false
+      }).and_raise(MarchHare::Exception)
+      # Failover to host2
+      expect(MarchHare).to receive(:connect).with({
+        :vhost => "/",
+        :host => "host2",
+        :port => 5672,
+        :user => "guest",
+        :pass => "guest",
+        :automatic_recovery => false
+      }).and_return(conn)
+      expect(conn).to receive(:create_channel).and_return(channel)
+      expect(channel).to receive(:exchange).with("foo", {
+        :type => :topic,
+        :durable => true
+      }).and_return(exchange)
+
+      # Publish and close
+      expect(exchange).to receive(:publish).with(an_instance_of(String), {
+        :routing_key => "bar",
+        :properties => {:persistent => true}
+      })
+
+      expect(conn).to receive(:open?).and_return(true)
+      expect(conn).to receive(:close)
+
+
+      # Run this scenerio
+      pipeline = LogStash::Pipeline.new(config)
+      pipeline.run
+    end
+
+  end
+
+  describe "failover to multiple ports" do
+    config <<-END
+      input {
+        generator {
+          count => 1
+        }
+      }
+      output {
+        rabbitmq {
+          host => ["host1:2345", "host2:6789"]
+          exchange_type => "topic"
+          exchange => "foo"
+          key => "bar"
+          debug => true
+        }
+      }
+    END
+
+    it "should accept multiple hosts" do
+      exchange = double("exchange")
+      conn = double("conn")
+      channel = double("channel")
+
+      # Connect to host1 at 2345
+      expect(MarchHare).to receive(:connect).with({
+        :vhost => "/",
+        :host => "host1",
+        :port => 2345,
+        :user => "guest",
+        :pass => "guest",
+        :automatic_recovery => false
+      }).and_return(conn)
+      expect(conn).to receive(:create_channel).and_return(channel)
+      expect(channel).to receive(:exchange).with("foo", {
+        :type => :topic,
+        :durable => true
+      }).and_return(exchange)
+
+      # Failover to host2 at 6789
+      expect(exchange).to receive(:publish).with(an_instance_of(String), {
+        :routing_key => "bar",
+        :properties => {:persistent => true}
+      }).and_raise(MarchHare::Exception)
+
+      expect(MarchHare).to receive(:connect).with({
+        :vhost => "/",
+        :host => "host2",
+        :port => 6789,
+        :user => "guest",
+        :pass => "guest",
+        :automatic_recovery => false
+      }).and_return(conn)
+      expect(conn).to receive(:create_channel).and_return(channel)
+      expect(channel).to receive(:exchange).with("foo", {
+        :type => :topic,
+        :durable => true
+      }).and_return(exchange)
+
+      # Failover back to host1 at 2345
+      expect(exchange).to receive(:publish).with(an_instance_of(String), {
+        :routing_key => "bar",
+        :properties => {:persistent => true}
+      }).and_raise(MarchHare::Exception)
+
+      expect(MarchHare).to receive(:connect).with({
+        :vhost => "/",
+        :host => "host1",
+        :port => 2345,
+        :user => "guest",
+        :pass => "guest",
+        :automatic_recovery => false
+      }).and_return(conn)
+      expect(conn).to receive(:create_channel).and_return(channel)
+      expect(channel).to receive(:exchange).with("foo", {
+        :type => :topic,
+        :durable => true
+      }).and_return(exchange)
+
+
+      # succeed and close
+      expect(exchange).to receive(:publish).with(an_instance_of(String), {
+        :routing_key => "bar",
+        :properties => {:persistent => true}
+      })
+
+      expect(conn).to receive(:open?).and_return(true)
+      expect(conn).to receive(:close)
+
+      pipeline = LogStash::Pipeline.new(config)
+      pipeline.run
+    end
+
+    it "should failover upon failing to connect" do
+      conn = double("conn")
+      channel = double("channel")
+      exchange = double("exchange")
+
+      # Fail to connect to host1 at 2345
+      expect(MarchHare).to receive(:connect).with({
+        :vhost => "/",
+        :host => "host1",
+        :port => 2345,
+        :user => "guest",
+        :pass => "guest",
+        :automatic_recovery => false
+      }).and_raise(MarchHare::Exception)
+      # Connect to host2 at 6789
+      expect(MarchHare).to receive(:connect).with({
+        :vhost => "/",
+        :host => "host2",
+        :port => 6789,
+        :user => "guest",
+        :pass => "guest",
+        :automatic_recovery => false
+      }).and_return(conn)
+      expect(conn).to receive(:create_channel).and_return(channel)
+      expect(channel).to receive(:exchange).with("foo", {
+        :type => :topic,
+        :durable => true
+      }).and_return(exchange)
+
+      # Publish and close
+      expect(exchange).to receive(:publish).with(an_instance_of(String), {
+        :routing_key => "bar",
+        :properties => {:persistent => true}
+      })
+
+      expect(conn).to receive(:open?).and_return(true)
+      expect(conn).to receive(:close)
+
+
+      # Run this scenerio
+      pipeline = LogStash::Pipeline.new(config)
+      pipeline.run
+    end
+
+
+  end
+
 end


### PR DESCRIPTION
This hack makes the RabbitMQ output failover to multiple RabbitMQ servers/ports in a round robin fashion.

It is fully backwards compatible but I've failed to entirely stop the dropping of messages whilst failing over.