### PR TITLE
[Feature] Allow multiple host

### DIFF
--- a/lib/logstash/outputs/rabbitmq.rb
+++ b/lib/logstash/outputs/rabbitmq.rb
@@ -21,7 +21,14 @@ class LogStash::Outputs::RabbitMQ < LogStash::Outputs::Base
   #
 
   # RabbitMQ server address
-  config :host, :validate => :string, :required => true
+  #  syntax allowed:
+  #   "127.0.0.1"
+  #   ["127.0.0.1", "127.0.0.2:5672"]
+  #
+  config :host, :validate => :array, :required => true
+
+  # RabbitMQ shuffle host before using
+  config :shuffle_hosts, :validate => :boolean, :default => true
 
   # RabbitMQ port to connect on
   config :port, :validate => :number, :default => 5672

--- a/lib/logstash/outputs/rabbitmq/march_hare.rb
+++ b/lib/logstash/outputs/rabbitmq/march_hare.rb
@@ -15,6 +15,9 @@ class LogStash::Outputs::RabbitMQ
 
       @connected = java.util.concurrent.atomic.AtomicBoolean.new
 
+      @host.shuffle! if @shuffle_hosts
+      @host_idx = 0
+
       connect
       @x = declare_exchange
 
@@ -59,7 +62,7 @@ class LogStash::Outputs::RabbitMQ
     end
 
     def to_s
-      return "amqp://#{@user}@#{@host}:#{@port}#{@vhost}/#{@exchange_type}/#{@exchange}\##{@key}"
+      return "amqp://#{@user}@#{@current_host}:#{@current_port}#{@vhost}/#{@exchange_type}/#{@exchange}\##{@key}"
     end
 
     def teardown
@@ -83,10 +86,15 @@ class LogStash::Outputs::RabbitMQ
       # 5672. Will be switched to 5671 by Bunny if TLS is enabled.
       @port        ||= 5672
 
+      @current_host, @current_port = @host[@host_idx].split(':')
+      @host_idx = @host_idx + 1 >= @host.length ? 0 : @host_idx + 1
+
+      @current_port = @port if not @current_port
+
       @settings = {
         :vhost => @vhost,
-        :host  => @host,
-        :port  => @port,
+        :host  => @current_host,
+        :port  => @current_port,
         :user  => @user,
         :automatic_recovery => false
       }
@@ -102,7 +110,7 @@ class LogStash::Outputs::RabbitMQ
                                else
                                  "amqps"
                                end
-      @connection_url        = "#{proto}://#{@user}@#{@host}:#{@port}#{vhost}/#{@queue}"
+      @connection_url        = "#{proto}://#{@user}@#{@current_host}:#{@current_port}#{vhost}/#{@queue}"
 
       begin
         @conn = MarchHare.connect(@settings)


### PR DESCRIPTION
Hi there, 

We are running a rabbitmq cluster, currently the output plugin does not support multiple hosts.  There might be a way to use multiple output configs but this might add message duplication.  This change will just randomise (optionally) the host param passed and connect to one of them, when reconnecting it will rotate the host array and retry.

This pull request will change the following

- [change] host parameter may now be an array
- [new] shuffle_hosts parameter will optionally shuffle the host array before use

this feature and code is nearly a direct copy of output/redis