### PR TITLE
Adds frame_max and timeout settings

### DIFF
--- a/lib/logstash/outputs/rabbitmq.rb
+++ b/lib/logstash/outputs/rabbitmq.rb
@@ -45,6 +45,9 @@ class LogStash::Outputs::RabbitMQ < LogStash::Outputs::Base
   # Try to automatically recovery from broken connections. You almost certainly don't want to override this!!!
   config :automatic_recovery, :validate => :boolean, :default => true
 
+  # The default connection timeout; zero means wait indefinitely
+  config :connection_timeout, :validate => :number, :required => false
+
   # The exchange type (fanout, topic, direct)
   config :exchange_type, :validate => EXCHANGE_TYPES, :required => true
 
@@ -126,6 +129,7 @@ class LogStash::Outputs::RabbitMQ < LogStash::Outputs::Base
       :automatic_recovery => @automatic_recovery,
       :pass => @password ? @password.value : "guest",
     }
+    s[:timeout] = @connection_timeout || MarchHare::ConnectionFactory::DEFAULT_CONNECTION_TIMEOUT
     s[:tls] = @ssl if @ssl
     @settings = s
   end


### PR DESCRIPTION
The timeout is available in both Bunny and March Hare. 
The frame_max is available in Bunny but I didn't find any reference in the March Hare code base.