### PR TITLE
Fix for #9, #10

### DIFF
--- a/lib/logstash/outputs/rabbitmq/march_hare.rb
+++ b/lib/logstash/outputs/rabbitmq/march_hare.rb
@@ -53,7 +53,7 @@ class LogStash::Outputs::RabbitMQ
         sleep n
 
         connect
-        declare_exchange
+        @x = declare_exchange
         retry
       end
     end
@@ -105,7 +105,7 @@ class LogStash::Outputs::RabbitMQ
       @connection_url        = "#{proto}://#{@user}@#{@host}:#{@port}#{vhost}/#{@queue}"
 
       begin
-        @conn = MarchHare.connect(@settings)
+        @conn = MarchHare.connect(@settings) unless @conn && @conn.open?
 
         @logger.debug("Connecting to RabbitMQ. Settings: #{@settings.inspect}, queue: #{@queue.inspect}")
 


### PR DESCRIPTION
Whenever a reconnect happened, a new connection was opened and the new rabbitmq channel was set up without being assigned to the class member @x. Every time the old (broken) channel was accessed, a new reconnect was triggered.