### PR TITLE
Fix connection duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* 1.1.1
+ - Fix nasty bug that caused connection duplication on conn recovery
 * 1.1.0
  - Many internal refactors
  - Bump march hare version to 2.11.0

--- a/lib/logstash/outputs/rabbitmq.rb
+++ b/lib/logstash/outputs/rabbitmq.rb
@@ -42,7 +42,7 @@ class LogStash::Outputs::RabbitMQ < LogStash::Outputs::Base
   # Enable or disable logging
   config :debug, :validate => :boolean, :default => false, :deprecated => "Use the logstash --debug flag for this instead."
 
-  # Try to automatically recover from a broken connections. You almost certainly don't want to override this!!!
+  # Set this to automatically recover from a broken connection. You almost certainly don't want to override this!!!
   config :automatic_recovery, :validate => :boolean, :default => true
 
   # The exchange type (fanout, topic, direct)

--- a/lib/logstash/outputs/rabbitmq.rb
+++ b/lib/logstash/outputs/rabbitmq.rb
@@ -163,7 +163,7 @@ class LogStash::Outputs::RabbitMQ < LogStash::Outputs::Base
 
   private
   def connect!
-    @hare_info = connect() unless @hare_info
+    @hare_info = connect()
   rescue MarchHare::Exception => e
     return if terminating?
 

--- a/lib/logstash/outputs/rabbitmq.rb
+++ b/lib/logstash/outputs/rabbitmq.rb
@@ -152,7 +152,7 @@ class LogStash::Outputs::RabbitMQ < LogStash::Outputs::Base
     @logger.debug("Declaring an exchange", :name => @exchange,
                   :type => @exchange_type, :durable => @durable)
     exchange = channel.exchange(@exchange, :type => @exchange_type.to_sym, :durable => @durable)
-    @logger.debug("Exchange declared", )
+    @logger.debug("Exchange declared")
     exchange
   rescue StandardError => e
     @logger.error("Could not declare exchange!",

--- a/lib/logstash/outputs/rabbitmq.rb
+++ b/lib/logstash/outputs/rabbitmq.rb
@@ -42,7 +42,7 @@ class LogStash::Outputs::RabbitMQ < LogStash::Outputs::Base
   # Enable or disable logging
   config :debug, :validate => :boolean, :default => false, :deprecated => "Use the logstash --debug flag for this instead."
 
-  # Try to automatically recovery from broken connections. You almost certainly don't want to override this!!!
+  # Try to automatically recover from a broken connections. You almost certainly don't want to override this!!!
   config :automatic_recovery, :validate => :boolean, :default => true
 
   # The exchange type (fanout, topic, direct)
@@ -98,7 +98,6 @@ class LogStash::Outputs::RabbitMQ < LogStash::Outputs::Base
                   :backtrace => e.backtrace)
 
     sleep_for_retry
-    connect!
     retry
   end
 
@@ -164,7 +163,7 @@ class LogStash::Outputs::RabbitMQ < LogStash::Outputs::Base
 
   private
   def connect!
-    @hare_info = connect() unless connection_open?
+    @hare_info = connect() unless @hare_info
   rescue MarchHare::Exception => e
     return if terminating?
 

--- a/logstash-output-rabbitmq.gemspec
+++ b/logstash-output-rabbitmq.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-rabbitmq'
-  s.version         = '1.1.0'
+  s.version         = '1.1.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Push events to a RabbitMQ exchange"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This fixes #9 . The latest version of march hare contains its own internal retry logic, so there is no need to call `#connect!` on each connection failure, that now duplicates a connection.

No specs were updated here because we actually removed functionality. The testing here is the responsibility of march_hare (and beyond that really the rabbitmq java library).

I have verified this by hand using a local rabbitmq server and the web UI to count connections and confirm message delivery (even when the server was down).