### PR TITLE
Bump march hare to 2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* 1.1.2
+ - Bump march_hare to 2.12.0 to fix jar file permissions
 * 1.1.1
  - Fix nasty bug that caused connection duplication on conn recovery
 * 1.1.0

--- a/logstash-output-rabbitmq.gemspec
+++ b/logstash-output-rabbitmq.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-rabbitmq'
-  s.version         = '1.1.1'
+  s.version         = '1.1.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Push events to a RabbitMQ exchange"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core", '>= 1.4.0', '< 2.0.0'
 
   s.platform = RUBY_PLATFORM
-  s.add_runtime_dependency 'march_hare', ['~> 2.11.0'] #(MIT license)
+  s.add_runtime_dependency 'march_hare', ['~> 2.12.0'] #(MIT license)
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'logstash-input-generator'


### PR DESCRIPTION
Upgrade from march hare 2.11.0 which had broken file permissions on a jar ( https://github.com/elastic/logstash/issues/3781 )

Companion fix to https://github.com/logstash-plugins/logstash-input-rabbitmq/pull/37