### PR TITLE
Fix the prefetch cache by bumping rabbitmq_connection dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+ - Support prefetch_count parameter via upgrade of rabbitmq_connection dependency
+
 ## 3.0.5
  - Fix broken registration of plugin
 

--- a/logstash-output-rabbitmq.gemspec
+++ b/logstash-output-rabbitmq.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-rabbitmq'
-  s.version         = '3.0.5'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Push events to a RabbitMQ exchange"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", ">= 2.0.0.beta2", "< 3.0.0"
-  s.add_runtime_dependency "logstash-mixin-rabbitmq_connection", '>= 2.0.1', '< 3.0.0'
+  s.add_runtime_dependency "logstash-mixin-rabbitmq_connection", '>= 2.1.1', '< 3.0.0'
 
   s.platform = RUBY_PLATFORM
 

--- a/spec/outputs/rabbitmq_spec.rb
+++ b/spec/outputs/rabbitmq_spec.rb
@@ -40,6 +40,7 @@ describe LogStash::Outputs::RabbitMQ do
       allow(connection).to receive(:on_blocked)
       allow(connection).to receive(:on_unblocked)
       allow(channel).to receive(:exchange).and_return(exchange)
+      allow(channel).to receive(:prefetch=)
 
       instance.register
     end


### PR DESCRIPTION
The `prefetch_count` parameter was missing. This has been added in the latest logstash-output-rabbitmq plugin.