### PR TITLE
Allow stubbed connection to receive on_shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+##
+  - Fix broken tests due to latest logstash-output-rabbitmq_connection
+
 ## 4.0.4
   - Depend on latest RMQ connection which retries on connection exception
 

--- a/logstash-output-rabbitmq.gemspec
+++ b/logstash-output-rabbitmq.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-rabbitmq'
-  s.version         = '4.0.4'
+  s.version         = '4.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Push events to a RabbitMQ exchange"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/rabbitmq_spec.rb
+++ b/spec/outputs/rabbitmq_spec.rb
@@ -39,6 +39,7 @@ describe LogStash::Outputs::RabbitMQ do
       allow(connection).to receive(:create_channel).and_return(channel)
       allow(connection).to receive(:on_blocked)
       allow(connection).to receive(:on_unblocked)
+      allow(connection).to receive(:on_shutdown)
       allow(channel).to receive(:exchange).and_return(exchange)
 
       instance.register


### PR DESCRIPTION
This fixes an improper test failure as a result of upgrading logstash-mixin-rabbitmq_connection . This will fix failing tests found in https://github.com/elastic/logstash/issues/5606