### PR TITLE
Bump rabbitmq connection to 4.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-##
+## 4.0.6
+  - Bump rabbitmq connection to fix LongString type usage
+
+## 4.0.5
   - Fix broken tests due to latest logstash-output-rabbitmq_connection
 
 ## 4.0.4

--- a/logstash-output-rabbitmq.gemspec
+++ b/logstash-output-rabbitmq.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-rabbitmq'
-  s.version         = '4.0.5'
+  s.version         = '4.0.6'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Push events to a RabbitMQ exchange"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency "logstash-mixin-rabbitmq_connection", '>= 4.1.1', '< 5.0.0'
+  s.add_runtime_dependency "logstash-mixin-rabbitmq_connection", '>= 4.2.2', '< 5.0.0'
 
   s.platform = RUBY_PLATFORM
 


### PR DESCRIPTION
This fixes the LongString issue that can affect RabbitMQ headers. This really doesn't affect the output AFAICT but is a good idea just in case, and brings this plugin in-line with the input.