### PR TITLE
Use shared concurrency for performance / simplicity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.1.0
+  _ Use shared concurrency / multiple channels for performance
+
 ## 5.0.3
   - Update gemspec summary
 

--- a/logstash-output-rabbitmq.gemspec
+++ b/logstash-output-rabbitmq.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-rabbitmq'
-  s.version         = '5.0.3'
+  s.version         = '5.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Pushes events to a RabbitMQ exchange"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/rabbitmq_spec.rb
+++ b/spec/outputs/rabbitmq_spec.rb
@@ -163,6 +163,7 @@ describe "with a live server", :integration => true do
     sleep 1
   end
   let(:message) { LogStash::Event.new("message" => "Foo Message", "extra_field" => "Blah") }
+  let(:encoded) { message.to_json }
   let(:test_connection) { MarchHare.connect(instance.send(:rabbitmq_settings)) }
   let(:test_channel) { test_connection.create_channel }
   let(:test_queue) {
@@ -196,7 +197,7 @@ describe "with a live server", :integration => true do
     end
 
     it 'applies per message settings' do
-      instance.receive(message)
+      instance.multi_receive_encoded([[message, encoded]])
       sleep 1.0
 
       message, payload = test_queue.pop
@@ -213,7 +214,7 @@ describe "with a live server", :integration => true do
         @received = payload
       end
 
-      instance.receive(message)
+      instance.multi_receive_encoded([[message, encoded]])
 
       until @received
         sleep 1


### PR DESCRIPTION
This should improve performance by letting the pipeline do the encoding and thus improving concurrency.

We need a thread local per channel since those are not threadsafe
  