### PR TITLE
fix for case sensitive rabbitmq message properties

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -168,11 +168,14 @@ Key to route to by default. Defaults to 'logstash'
   * Value type is <<hash,hash>>
   * Default value is `{}`
 
-Add properties to be set per-message here, such as 'Content-Type', 'Priority'
+Add properties to be set per-message here, such as 'content_type', 'priority'
 
 Example:
 [source,ruby]
-    message_properties => { "priority" => "1" }
+    message_properties => {
+      "content_type" => "application/json"  
+      "priority" => 1
+    }
 
 
 [id="plugins-{type}s-{plugin}-passive"]


### PR DESCRIPTION
... Additionally, `priority` field only accepts integer values.

Tested on: RabbitMQ 3.7.3 and Logstash 6.4.2

I have signed CLA.
