### PR TITLE
point users+contributors to integration source

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,11 @@
-Please post all product and debugging questions on our [forum](https://discuss.elastic.co/c/logstash). Your questions will reach our wider community members there, and if we confirm that there is a bug, then we can open a new issue here.
+## RabbitMQ Output Plugin's Issue Tracker Has Moved
 
-For all general issues, please provide the following details for fast resolution:
+This RabbitMQ Output Plugin is now a part of the [RabbitMQ Integration Plugin][integration-source];
+this project remains open for backports of fixes from that project to the 5.x series where possible, but issues should first be filed on the [integration plugin][integration-issues].
 
-- Version:
-- Operating System:
-- Config File (if you have sensitive info, please remove it):
-- Sample Data:
-- Steps to Reproduce:
+Please post all product and debugging questions on our [forum][logstash-forum].
+Your questions will reach our wider community members there, and if we confirm that there is a bug, then we can open a new issue on the appropriate project.
+
+[integration-source]: https://github.com/logstash-plugins/logstash-integration-rabbitmq
+[integration-issues]: https://github.com/logstash-plugins/logstash-integration-rabbitmq/issues/
+[logstash-forum]: https://discuss.elastic.co/c/logstash

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,14 @@
+## RabbitMQ Output Plugin's Source Has Moved
+
+This RabbitMQ Output Plugin is now a part of the [RabbitMQ Integration Plugin][integration-source];
+this project remains open for backports of fixes from that project to the 6.x series where possible, but pull-requests should first be made on the [integration plugin][integration-pull-requests].
+
+If you have already made commits on a clone of this stand-alone repository, it's ok! Go ahead and open the Pull Request here, and open an Issue linking to it on the [integration plugin][integration-issues] -- we'll work with you to sort it all out and to get the backport applied.
+
+## Contributor Agreement
+
 Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
+
+[integration-source]: https://github.com/logstash-plugins/logstash-integration-rabbitmq
+[integration-issues]: https://github.com/logstash-plugins/logstash-integration-rabbitmq/issues/
+[integration-pull-requests]: https://github.com/logstash-plugins/logstash-integration-rabbitmq/pulls

--- a/README.md
+++ b/README.md
@@ -2,5 +2,106 @@
 
 [![Travis Build Status](https://travis-ci.org/logstash-plugins/logstash-output-rabbitmq.svg)](https://travis-ci.org/logstash-plugins/logstash-output-rabbitmq)
 
-This is a mixin supporting  the logstash rabbitmq inputs and outputs. If you plan on writing a logstash plugin using
-rabbitmq this may be useful.
+This is a plugin for [Logstash](https://github.com/elastic/logstash).
+
+It is fully free and fully open source. The license is Apache 2.0, meaning you are pretty much free to use it however you want in whatever way.
+
+
+## RabbitMQ Output Plugin Has Moved
+
+This RabbitMQ Output Plugin is now a part of the [RabbitMQ Integration Plugin][integration-source];
+this project remains open for backports of fixes from that project to the 5.x series where possible, but issues should first be filed on the [integration plugin][integration-issues].
+
+[integration-source]: https://github.com/logstash-plugins/logstash-integration-rabbitmq
+[integration-issues]: https://github.com/logstash-plugins/logstash-integration-rabbitmq/issues/
+
+## Documentation
+
+Logstash provides infrastructure to automatically generate documentation for this plugin. We use the asciidoc format to write documentation so any comments in the source code will be first converted into asciidoc and then into html. All plugin documentation are placed under one [central location](http://www.elastic.co/guide/en/logstash/current/).
+
+- For formatting code or config example, you can use the asciidoc `[source,ruby]` directive
+- For more asciidoc formatting tips, see the excellent reference here https://github.com/elastic/docs#asciidoc-guide
+
+## Need Help?
+
+Need help? Try #logstash on freenode IRC or the https://discuss.elastic.co/c/logstash discussion forum.
+
+## Developing
+
+### 1. Plugin Developement and Testing
+
+#### Code
+- To get started, you'll need JRuby with the Bundler gem installed.
+
+- Create a new plugin or clone and existing from the GitHub [logstash-plugins](https://github.com/logstash-plugins) organization. We also provide [example plugins](https://github.com/logstash-plugins?query=example).
+
+- Install dependencies
+```sh
+bundle install
+```
+
+#### Test
+
+- Update your dependencies
+
+```sh
+bundle install
+```
+
+- Run tests
+
+```sh
+bundle exec rspec
+```
+
+### 2. Running your unpublished Plugin in Logstash
+
+#### 2.1 Run in a local Logstash clone
+
+- Edit Logstash `Gemfile` and add the local plugin path, for example:
+```ruby
+gem "logstash-filter-awesome", :path => "/your/local/logstash-filter-awesome"
+```
+- Install plugin
+```sh
+# Logstash 2.3 and higher
+bin/logstash-plugin install --no-verify
+
+# Prior to Logstash 2.3
+bin/plugin install --no-verify
+
+```
+- Run Logstash with your plugin
+```sh
+bin/logstash -e 'filter {awesome {}}'
+```
+At this point any modifications to the plugin code will be applied to this local Logstash setup. After modifying the plugin, simply rerun Logstash.
+
+#### 2.2 Run in an installed Logstash
+
+You can use the same **2.1** method to run your plugin in an installed Logstash by editing its `Gemfile` and pointing the `:path` to your local plugin development directory or you can build the gem and install it using:
+
+- Build your plugin gem
+```sh
+gem build logstash-filter-awesome.gemspec
+```
+- Install the plugin from the Logstash home
+```sh
+# Logstash 2.3 and higher
+bin/logstash-plugin install --no-verify
+
+# Prior to Logstash 2.3
+bin/plugin install --no-verify
+
+```
+- Start Logstash and proceed to test the plugin
+
+## Contributing
+
+All contributions are welcome: ideas, patches, documentation, bug reports, complaints, and even something you drew up on a napkin.
+
+Programming is not a required skill. Whatever you've seen about open source and maintainers or community members  saying "send patches or die" - you will not see that here.
+
+It is more important to the community that you are able to contribute.
+
+For more information about contributing, see the [CONTRIBUTING](https://github.com/elastic/logstash/blob/master/CONTRIBUTING.md) file.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -2,6 +2,16 @@
 :type: output
 :default_codec: json
 
+/////////////////////////////////////////////
+// RabbitMQ Output Plugin Source Has Moved  //
+// ---------------------------------------- //
+// The RabbitMQ Output Plugin is now a part //
+// of the RabbitMQ Integration.             //
+//                                          //
+// This stand-alone plugin project remains  //
+// open for backports to the 5.x series.    //
+//////////////////////////////////////////////
+
 ///////////////////////////////////////////
 START - GENERATED VARIABLES, DO NOT EDIT!
 ///////////////////////////////////////////


### PR DESCRIPTION
This PR is the counterpart of the already-approved logstash-plugins/logstash-input-rabbitmq#125 as it applies to the RabbitMQ Output Plugin.

It does not require a version bump or changelog entry, as everything is contributor-facing and will change neither the gem artifact nor the docs build.